### PR TITLE
gateway-config: Don't assume default namespace

### DIFF
--- a/templates/services/gateway.tmpl.yaml
+++ b/templates/services/gateway.tmpl.yaml
@@ -55,8 +55,6 @@ kind: ConfigMap
 metadata:
   creationTimestamp: 2017-12-20T15:46:34Z
   name: gateway-config
-  namespace: default
-  selfLink: /api/v1/namespaces/default/configmaps/gateway-config
 ---
 apiVersion: apps/v1beta1
 kind: Deployment


### PR DESCRIPTION
This change allows you to deploy this product to whatever namespace
you choose.

Signed-off-by: Andy Doan <andy@opensourcefoundries.com>