### PR TITLE
RFC: Consolidate Ingress Logic

### DIFF
--- a/scripts/container_run.sh
+++ b/scripts/container_run.sh
@@ -39,9 +39,10 @@ print_pod_name() {
 }
 
 print_hosts() {
-  try_command ingress false "${KUBECTL} get ingress -o json \
-    | jq --exit-status '.items[0].status.loadBalancer.ingress'"
-  ${KUBECTL} get ingress --no-headers | awk '{print $3 " " $2}'
+  try_command ingress false "${KUBECTL} get ingress ota -o json \
+    | jq --exit-status '.status.loadBalancer.ingress'"
+  ${KUBECTL} get ingress ota -o jsonpath \
+      --template='{.status.loadBalancer.ingress[0].ip}{"\t\t"}{.spec.rules[*].host}{"\t"}'
 }
 
 wait_for_service() {

--- a/templates/services/app.tmpl.yaml
+++ b/templates/services/app.tmpl.yaml
@@ -111,6 +111,7 @@ kind: Service
 metadata:
   name: app
 spec:
+  type: NodePort
   ports:
   - port: 80
     targetPort: 9001

--- a/templates/services/app.tmpl.yaml
+++ b/templates/services/app.tmpl.yaml
@@ -82,21 +82,6 @@ spec:
       imagePullSecrets:
       - name: docker-registry-key
 ---
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: app
-  annotations:
-    kubernetes.io/ingress.class: nginx
-spec:
-  rules:
-  - host: app.{{ .ingress_dns_name }}
-    http:
-      paths:
-      - backend:
-          serviceName: app
-          servicePort: 80
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/templates/services/campaigner.tmpl.yaml
+++ b/templates/services/campaigner.tmpl.yaml
@@ -88,6 +88,7 @@ kind: Service
 metadata:
   name: campaigner
 spec:
+  type: NodePort
   ports:
   - port: 80
     targetPort: 9001

--- a/templates/services/campaigner.tmpl.yaml
+++ b/templates/services/campaigner.tmpl.yaml
@@ -60,21 +60,6 @@ spec:
       imagePullSecrets:
       - name: docker-registry-key
 ---
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: campaigner
-  annotations:
-    kubernetes.io/ingress.class: nginx
-spec:
-  rules:
-  - host: campaigner.{{ .ingress_dns_name }}
-    http:
-      paths:
-      - backend:
-          serviceName: campaigner
-          servicePort: 80
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/templates/services/device-registry.tmpl.yaml
+++ b/templates/services/device-registry.tmpl.yaml
@@ -83,6 +83,7 @@ kind: Service
 metadata:
   name: device-registry
 spec:
+  type: NodePort
   ports:
   - port: 80
     targetPort: 9001

--- a/templates/services/device-registry.tmpl.yaml
+++ b/templates/services/device-registry.tmpl.yaml
@@ -55,21 +55,6 @@ spec:
       imagePullSecrets:
       - name: docker-registry-key
 ---
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: device-registry
-  annotations:
-    kubernetes.io/ingress.class: nginx
-spec:
-  rules:
-  - host: device-registry.{{ .ingress_dns_name }}
-    http:
-      paths:
-      - backend:
-          serviceName: device-registry
-          servicePort: 80
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/templates/services/director.tmpl.yaml
+++ b/templates/services/director.tmpl.yaml
@@ -86,6 +86,7 @@ kind: Service
 metadata:
   name: director
 spec:
+  type: NodePort
   ports:
   - port: 80
     targetPort: 9001

--- a/templates/services/director.tmpl.yaml
+++ b/templates/services/director.tmpl.yaml
@@ -58,21 +58,6 @@ spec:
       imagePullSecrets:
       - name: docker-registry-key
 ---
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: director
-  annotations:
-    kubernetes.io/ingress.class: nginx
-spec:
-  rules:
-  - host: director.{{ .ingress_dns_name }}
-    http:
-      paths:
-      - backend:
-          serviceName: director
-          servicePort: 80
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/templates/services/ingress.tmpl.yaml
+++ b/templates/services/ingress.tmpl.yaml
@@ -1,0 +1,135 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: app
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+  - host: app.{{ .ingress_dns_name }}
+    http:
+      paths:
+      - backend:
+          serviceName: app
+          servicePort: 80
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: campaigner
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+  - host: campaigner.{{ .ingress_dns_name }}
+    http:
+      paths:
+      - backend:
+          serviceName: campaigner
+          servicePort: 80
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: device-registry
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+  - host: device-registry.{{ .ingress_dns_name }}
+    http:
+      paths:
+      - backend:
+          serviceName: device-registry
+          servicePort: 80
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: director
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+  - host: director.{{ .ingress_dns_name }}
+    http:
+      paths:
+      - backend:
+          serviceName: director
+          servicePort: 80
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: treehub
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    ingress.kubernetes.io/proxy-body-size: 30m
+spec:
+  rules:
+  - host: treehub.{{ .ingress_dns_name }}
+    http:
+      paths:
+      - backend:
+          serviceName: treehub
+          servicePort: 80
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: tuf-keyserver
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+  - host: tuf-keyserver.{{ .ingress_dns_name }}
+    http:
+      paths:
+      - backend:
+          serviceName: tuf-keyserver
+          servicePort: 80
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: tuf-reposerver
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+  - host: tuf-reposerver.{{ .ingress_dns_name }}
+    http:
+      paths:
+      - backend:
+          serviceName: tuf-reposerver
+          servicePort: 80
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: tuf-vault
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+  - host: tuf-vault.{{ .ingress_dns_name }}
+    http:
+      paths:
+      - backend:
+          serviceName: tuf-vault
+          servicePort: 80
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: web-events
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+  - host: web-events.{{ .ingress_dns_name }}
+    http:
+      paths:
+      - backend:
+          serviceName: web-events
+          servicePort: 80

--- a/templates/services/ingress.tmpl.yaml
+++ b/templates/services/ingress.tmpl.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: app
+  name: ota
   annotations:
     kubernetes.io/ingress.class: nginx
 spec:
@@ -12,121 +12,48 @@ spec:
       - backend:
           serviceName: app
           servicePort: 80
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: campaigner
-  annotations:
-    kubernetes.io/ingress.class: nginx
-spec:
-  rules:
   - host: campaigner.{{ .ingress_dns_name }}
     http:
       paths:
       - backend:
           serviceName: campaigner
           servicePort: 80
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: device-registry
-  annotations:
-    kubernetes.io/ingress.class: nginx
-spec:
-  rules:
   - host: device-registry.{{ .ingress_dns_name }}
     http:
       paths:
       - backend:
           serviceName: device-registry
           servicePort: 80
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: director
-  annotations:
-    kubernetes.io/ingress.class: nginx
-spec:
-  rules:
   - host: director.{{ .ingress_dns_name }}
     http:
       paths:
       - backend:
           serviceName: director
           servicePort: 80
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: treehub
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    ingress.kubernetes.io/proxy-body-size: 30m
-spec:
-  rules:
   - host: treehub.{{ .ingress_dns_name }}
     http:
       paths:
       - backend:
           serviceName: treehub
           servicePort: 80
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: tuf-keyserver
-  annotations:
-    kubernetes.io/ingress.class: nginx
-spec:
-  rules:
   - host: tuf-keyserver.{{ .ingress_dns_name }}
     http:
       paths:
       - backend:
           serviceName: tuf-keyserver
           servicePort: 80
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: tuf-reposerver
-  annotations:
-    kubernetes.io/ingress.class: nginx
-spec:
-  rules:
   - host: tuf-reposerver.{{ .ingress_dns_name }}
     http:
       paths:
       - backend:
           serviceName: tuf-reposerver
           servicePort: 80
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: tuf-vault
-  annotations:
-    kubernetes.io/ingress.class: nginx
-spec:
-  rules:
   - host: tuf-vault.{{ .ingress_dns_name }}
     http:
       paths:
       - backend:
           serviceName: tuf-vault
           servicePort: 80
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: web-events
-  annotations:
-    kubernetes.io/ingress.class: nginx
-spec:
-  rules:
   - host: web-events.{{ .ingress_dns_name }}
     http:
       paths:

--- a/templates/services/treehub.tmpl.yaml
+++ b/templates/services/treehub.tmpl.yaml
@@ -116,6 +116,7 @@ kind: Service
 metadata:
   name: treehub
 spec:
+  type: NodePort
   ports:
   - port: 80
     targetPort: 9001

--- a/templates/services/treehub.tmpl.yaml
+++ b/templates/services/treehub.tmpl.yaml
@@ -85,22 +85,6 @@ spec:
         persistentVolumeClaim:
           claimName: treehub-pv-claim
 ---
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: treehub
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    ingress.kubernetes.io/proxy-body-size: 30m
-spec:
-  rules:
-  - host: treehub.{{ .ingress_dns_name }}
-    http:
-      paths:
-      - backend:
-          serviceName: treehub
-          servicePort: 80
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/templates/services/tuf-keyserver.tmpl.yaml
+++ b/templates/services/tuf-keyserver.tmpl.yaml
@@ -84,6 +84,7 @@ kind: Service
 metadata:
   name: tuf-keyserver
 spec:
+  type: NodePort
   ports:
   - port: 80
     targetPort: 9001

--- a/templates/services/tuf-keyserver.tmpl.yaml
+++ b/templates/services/tuf-keyserver.tmpl.yaml
@@ -55,21 +55,6 @@ spec:
       imagePullSecrets:
       - name: docker-registry-key
 ---
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: tuf-keyserver
-  annotations:
-    kubernetes.io/ingress.class: nginx
-spec:
-  rules:
-  - host: tuf-keyserver.{{ .ingress_dns_name }}
-    http:
-      paths:
-      - backend:
-          serviceName: tuf-keyserver
-          servicePort: 80
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/templates/services/tuf-reposerver.tmpl.yaml
+++ b/templates/services/tuf-reposerver.tmpl.yaml
@@ -57,21 +57,6 @@ spec:
       imagePullSecrets:
       - name: docker-registry-key
 ---
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: tuf-reposerver
-  annotations:
-    kubernetes.io/ingress.class: nginx
-spec:
-  rules:
-  - host: tuf-reposerver.{{ .ingress_dns_name }}
-    http:
-      paths:
-      - backend:
-          serviceName: tuf-reposerver
-          servicePort: 80
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/templates/services/tuf-reposerver.tmpl.yaml
+++ b/templates/services/tuf-reposerver.tmpl.yaml
@@ -87,6 +87,7 @@ kind: Service
 metadata:
   name: tuf-reposerver
 spec:
+  type: NodePort
   ports:
   - port: 80
     targetPort: 9001

--- a/templates/services/web-events.tmpl.yaml
+++ b/templates/services/web-events.tmpl.yaml
@@ -52,21 +52,6 @@ spec:
       imagePullSecrets:
       - name: docker-registry-key
 ---
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: web-events
-  annotations:
-    kubernetes.io/ingress.class: nginx
-spec:
-  rules:
-  - host: web-events.{{ .ingress_dns_name }}
-    http:
-      paths:
-      - backend:
-          serviceName: web-events
-          servicePort: 80
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/templates/services/web-events.tmpl.yaml
+++ b/templates/services/web-events.tmpl.yaml
@@ -80,6 +80,7 @@ kind: Service
 metadata:
   name: web-events
 spec:
+  type: NodePort
   ports:
   - port: 80
     targetPort: 9001

--- a/templates/vault/tuf-vault.tmpl.yaml
+++ b/templates/vault/tuf-vault.tmpl.yaml
@@ -54,21 +54,6 @@ spec:
       imagePullSecrets:
       - name: docker-registry-key
 ---
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: tuf-vault
-  annotations:
-    kubernetes.io/ingress.class: nginx
-spec:
-  rules:
-  - host: tuf-vault.{{ .ingress_dns_name }}
-    http:
-      paths:
-      - backend:
-          serviceName: tuf-vault
-          servicePort: 80
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/templates/vault/tuf-vault.tmpl.yaml
+++ b/templates/vault/tuf-vault.tmpl.yaml
@@ -82,6 +82,7 @@ kind: Service
 metadata:
   name: tuf-vault
 spec:
+  type: NodePort
   ports:
   - port: 80
     targetPort: 8200


### PR DESCRIPTION
This patchset consolidates all the Ingress controllers so that a single load balancer can manage everything. This made things a lot easier inside the GCE. However, I also think it simplifies things for everyone.

I could see this series being somewhat controversial. If so, I'd like you to consider a couple of compromises.

1) Just cherry-pick the first patch in the series for "type: NodePort".
2) Cherry-pick the first two patches that get things with a  NodePort and also use a single ingress.yml file. That would then make things easier for me to manage potential out-of-tree patches.

Another option if the last patch seems awful: We could define a config value in config.yml that would allow a user to opt-in to using a consolidated Ingress so that things stay how they are unless someone really wants things like I'm proposing.