### PR TITLE
gateway: Expose endpoints to aktualizr

### DIFF
--- a/templates/services/gateway.tmpl.yaml
+++ b/templates/services/gateway.tmpl.yaml
@@ -110,10 +110,6 @@ metadata:
   name: gateway-service
 spec:
   ports:
-     - name: http
-       port: 80
-       protocol: TCP
-       targetPort: 80
      - name: https
        port: 8443
        protocol: TCP

--- a/templates/services/gateway.tmpl.yaml
+++ b/templates/services/gateway.tmpl.yaml
@@ -38,6 +38,16 @@ data:
         proxy_pass http://repo;
       }
 
+      location /core/system_info {
+        rewrite ^/core/(.*)$ /api/v1/mydevice/$deviceUuid/$1 break;
+        proxy_set_header x-ats-namespace $deviceNamespace;
+        proxy_pass http://device-registry;
+      }
+      location /core/installed {
+        rewrite ^/core/(.*)$ /api/v1/mydevice/$deviceUuid/packages break;
+        proxy_set_header x-ats-namespace $deviceNamespace;
+        proxy_pass http://device-registry;
+      }
     }
   upstreams.conf: |-
     upstream treehub {


### PR DESCRIPTION
Aktualizr uses two endpoints to send information about the target device:
*  /core/system_info
*  /core/packages

This provides the mapping into the OTA endpoints that can handle these actions.