### PR TITLE
[RFC] platform: Convert to StatefulSets

### DIFF
--- a/templates/platform/kafka.tmpl.yaml
+++ b/templates/platform/kafka.tmpl.yaml
@@ -72,31 +72,23 @@ spec:
             cpu: {{ .kafka_cpu }}
             memory: {{ .kafka_mem }}
         volumeMounts:
-        - name: data
+        - name: platform-vol
           mountPath: /opt/kafka/data
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
-      volumes:
-      - name: data
-        persistentVolumeClaim:
-          claimName: kafka-pv-claim
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: kafka-pv-claim
-  labels:
-    app: kafka
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi
-  selector:
-    matchLabels:
-      volume: kafka
+
+  volumeClaimTemplates:
+  - metadata:
+      name: platform-vol
+      annotations:
+        volume.beta.kubernetes.io/storage-class: fast
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
 ---
 apiVersion: v1
 kind: Service

--- a/templates/platform/mysql.tmpl.yaml
+++ b/templates/platform/mysql.tmpl.yaml
@@ -6,15 +6,14 @@ metadata:
 data:
 ---
 apiVersion: apps/v1beta2
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: mysql
 spec:
   selector:
     matchLabels:
       app: mysql
-  strategy:
-    type: Recreate
+  serviceName: mysql
   template:
     metadata:
       labels:
@@ -31,7 +30,10 @@ spec:
         - containerPort: 3306
           name: mysql
         volumeMounts:
-        - name: mysql-persistent-storage
+        - name: platform-vol
+          # subPath required so volume's lost+found
+          # directory doesn't break mysql's init
+          subPath: mysql_data
           mountPath: /var/lib/mysql
         livenessProbe:
           exec:
@@ -46,26 +48,18 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 2
           timeoutSeconds: 1
-      volumes:
-      - name: mysql-persistent-storage
-        persistentVolumeClaim:
-          claimName: mysql-pv-claim
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: mysql-pv-claim
-  labels:
-    app: mysql
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi
-  selector:
-    matchLabels:
-      volume: mysql
+
+  volumeClaimTemplates:
+  - metadata:
+      name: platform-vol
+      annotations:
+        volume.beta.kubernetes.io/storage-class: fast
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
 ---
 apiVersion: v1
 kind: Secret

--- a/templates/platform/volumes.yaml
+++ b/templates/platform/volumes.yaml
@@ -36,18 +36,3 @@ spec:
     - ReadWriteOnce
   hostPath:
     path: /data/zookeeper-pv-1
----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: kafka-pv-1
-  labels:
-    type: local
-    volume: kafka
-spec:
-  capacity:
-    storage: 1Gi
-  accessModes:
-    - ReadWriteOnce
-  hostPath:
-    path: /data/kafka-pv-1

--- a/templates/platform/volumes.yaml
+++ b/templates/platform/volumes.yaml
@@ -1,3 +1,11 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: fast
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -13,21 +21,6 @@ spec:
     - ReadWriteOnce
   hostPath:
     path: /data/treehub-pv-1
----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: mysql-pv-1
-  labels:
-    type: local
-    volume: mysql
-spec:
-  capacity:
-    storage: 1Gi
-  accessModes:
-    - ReadWriteOnce
-  hostPath:
-    path: /data/mysql-pv-1
 ---
 apiVersion: v1
 kind: PersistentVolume

--- a/templates/platform/volumes.yaml
+++ b/templates/platform/volumes.yaml
@@ -21,18 +21,3 @@ spec:
     - ReadWriteOnce
   hostPath:
     path: /data/treehub-pv-1
----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: zookeeper-pv-1
-  labels:
-    type: local
-    volume: zookeeper
-spec:
-  capacity:
-    storage: 1Gi
-  accessModes:
-    - ReadWriteOnce
-  hostPath:
-    path: /data/zookeeper-pv-1

--- a/templates/platform/zookeeper.tmpl.yaml
+++ b/templates/platform/zookeeper.tmpl.yaml
@@ -72,30 +72,22 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/lib/zookeeper
-          name: data
+          name: platform-vol
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
-      volumes:
-      - name: data
-        persistentVolumeClaim:
-          claimName: zookeeper-pv-claim
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: zookeeper-pv-claim
-  labels:
-    app: zookeeper
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi
-  selector:
-    matchLabels:
-      volume: zookeeper
+
+  volumeClaimTemplates:
+  - metadata:
+      name: platform-vol
+      annotations:
+        volume.beta.kubernetes.io/storage-class: fast
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Persistent volumes can be a bit of a pain in k8s. Additionally, they are being used on things that seem better served and simplified as StatefulSets. I think this produces something easier to understand and manage. Additionally - moving MySQL over could open you up to the ability to make it HA:

  https://github.com/doanac/k8s-percona-xtradb-cluster