### PR TITLE
templates: Add a method for local overrides

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -65,6 +65,8 @@ kill_pid() {
 make_template() {
   local template=$1
   local output="${CWD}/../generated/${template}"
+  local extra=""
+  [ -f config/local.yaml ] && extra="--values config/local.yaml"
   mkdir -p "$(dirname "${output}")"
   kops toolbox template \
     --template "${template}" \
@@ -72,6 +74,7 @@ make_template() {
     --values config/infra.yaml \
     --values config/secrets.yaml \
     --values config/resources.yaml \
+    ${extra} \
     --output "${output}"
 }
 


### PR DESCRIPTION
This lets you maintain a set of non-default options without having
to fork the repo.

Signed-off-by: Andy Doan <andy@opensourcefoundries.com>