### PR TITLE
gateway: Expose the device registry network endpoint

### DIFF
--- a/templates/services/gateway.tmpl.yaml
+++ b/templates/services/gateway.tmpl.yaml
@@ -52,6 +52,11 @@ data:
         proxy_set_header x-ats-namespace $deviceNamespace;
         proxy_pass http://device-registry;
       }
+      location /system_info/network {
+        rewrite ^/system_info/(.*)$ /api/v1/devices/$deviceUuid/system_info/network break;
+        proxy_set_header x-ats-namespace $deviceNamespace;
+        proxy_pass http://device-registry;
+      }
     }
   upstreams.conf: |-
     upstream treehub {

--- a/templates/services/gateway.tmpl.yaml
+++ b/templates/services/gateway.tmpl.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   gateway.conf: |-
     server {
-      error_log  /var/log/nginx/error.log debug;
+      error_log  /var/log/nginx/error.log info;
       listen       8443 ssl;
       server_name ota.ce;
       ssl_certificate     /etc/ssl/gateway/server.chain.pem;


### PR DESCRIPTION
I'm not a huge fan of this change as it seems aktualizr and the device-registry have
an odd mapping of their apis that's quite easy to get wrong. It does get things working
though.