### PR TITLE
Convert statefulSets to use volumeClaimTemplates

### DIFF
--- a/templates/infra/kafka.tmpl.yaml
+++ b/templates/infra/kafka.tmpl.yaml
@@ -85,47 +85,23 @@ spec:
             cpu: {{ .kafka_cpu }}
             memory: {{ .kafka_mem }}
         volumeMounts:
-        - name: kafka-data
+        - name: infra-vol
           mountPath: /opt/kafka/data
           subPath: kafka
-      volumes:
-      - name: kafka-data
-        persistentVolumeClaim:
-          claimName: kafka-pvc
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: kafka-pvc
-spec:
-  accessModes: [ "ReadWriteOnce" ]
-  resources:
-    requests:
-      storage: 10Gi
-  {{- if .persistent_volumes_path}}
-  selector:
-    matchLabels:
-      volume: kafka-pv
-  {{- end}}
-  {{- if .storage_class_name}}
-  storageClassName: {{ .storage_class_name }}
-  {{- end}}
----
-{{- if .persistent_volumes_path}}
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: kafka-pv
-  labels:
-    volume: kafka-pv
-spec:
-  capacity:
-    storage: {{ .kafka_disk }}
-  accessModes: [ "ReadWriteOnce" ]
-  persistentVolumeReclaimPolicy: Retain
-  hostPath:
-    path: {{ .persistent_volumes_path }}
-{{- end}}
+
+  volumeClaimTemplates:
+  - metadata:
+      name: infra-vol
+      {{- if .storage_class_name}}
+      annotations:
+        volume.beta.kubernetes.io/storage-class: {{ .storage_class_name }}
+      {{- end}}
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: {{ .kafka_disk }}
 ---
 apiVersion: v1
 kind: Service

--- a/templates/infra/mysql.tmpl.yaml
+++ b/templates/infra/mysql.tmpl.yaml
@@ -43,47 +43,23 @@ spec:
           periodSeconds: 2
           timeoutSeconds: 1
         volumeMounts:
-        - name: mysql-data
+        - name: infra-vol
           mountPath: /var/lib/mysql
           subPath: mysql
-      volumes:
-      - name: mysql-data
-        persistentVolumeClaim:
-          claimName: mysql-pvc
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: mysql-pvc
-spec:
-  accessModes: [ "ReadWriteOnce" ]
-  resources:
-    requests:
-      storage: {{ .mysql_disk }}
-  {{- if .persistent_volumes_path}}
-  selector:
-    matchLabels:
-      volume: mysql-pv
-  {{- end}}
-  {{- if .storage_class_name}}
-  storageClassName: {{ .storage_class_name }}
-  {{- end}}
----
-{{- if .persistent_volumes_path}}
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: mysql-pv
-  labels:
-    volume: mysql-pv
-spec:
-  capacity:
-    storage: 10Gi
-  accessModes: [ "ReadWriteOnce" ]
-  persistentVolumeReclaimPolicy: Retain
-  hostPath:
-    path: {{ .persistent_volumes_path }}
-{{- end}}
+
+  volumeClaimTemplates:
+  - metadata:
+      name: infra-vol
+      {{- if .storage_class_name}}
+      annotations:
+        volume.beta.kubernetes.io/storage-class: {{ .storage_class_name }}
+      {{- end}}
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: {{ .mysql_disk }}
 ---
 apiVersion: v1
 kind: Secret

--- a/templates/infra/zookeeper.tmpl.yaml
+++ b/templates/infra/zookeeper.tmpl.yaml
@@ -69,47 +69,23 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - name: zookeeper-data
+        - name: infra-vol
           mountPath: /var/lib/zookeeper
           subPath: zookeeper
-      volumes:
-      - name: zookeeper-data
-        persistentVolumeClaim:
-          claimName: zookeeper-pvc
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: zookeeper-pvc
-spec:
-  accessModes: [ "ReadWriteOnce" ]
-  resources:
-    requests:
-      storage: {{ .zookeeper_disk }}
-  {{- if .persistent_volumes_path}}
-  selector:
-    matchLabels:
-      volume: zookeeper-pv
-  {{- end}}
-  {{- if .storage_class_name}}
-  storageClassName: {{ .storage_class_name }}
-  {{- end}}
----
-{{- if .persistent_volumes_path}}
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: zookeeper-pv
-  labels:
-    volume: zookeeper-pv
-spec:
-  capacity:
-    storage: 10Gi
-  accessModes: [ "ReadWriteOnce" ]
-  persistentVolumeReclaimPolicy: Retain
-  hostPath:
-    path: {{ .persistent_volumes_path }}
-{{- end}}
+
+  volumeClaimTemplates:
+  - metadata:
+      name: infra-vol
+      {{- if .storage_class_name}}
+      annotations:
+        volume.beta.kubernetes.io/storage-class: {{ .storage_class_name }}
+      {{- end}}
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: {{ .zookeeper_disk }}
 ---
 apiVersion: v1
 kind: Service

--- a/templates/services/treehub.tmpl.yaml
+++ b/templates/services/treehub.tmpl.yaml
@@ -41,7 +41,7 @@ spec:
         image: {{ .init_docker_image }}
         command: ["sh", "-c", "chown --recursive 2:2 /treehub-objects"]
         volumeMounts:
-        - name: treehub-data
+        - name: infra-vol
           mountPath: /treehub-objects
       {{- end}}
       containers:
@@ -68,14 +68,24 @@ spec:
             path: "/health"
       {{- if eq .treehub_storage "local"}}
         volumeMounts:
-        - name: treehub-data
+        - name: infra-vol
           mountPath: /treehub-objects
           subPath: treehub-objects
-      volumes:
-      - name: treehub-data
-        persistentVolumeClaim:
-          claimName: treehub-pvc
       {{- end}}
+
+  volumeClaimTemplates:
+  - metadata:
+      name: infra-vol
+      {{- if .storage_class_name}}
+      annotations:
+        volume.beta.kubernetes.io/storage-class: {{ .storage_class_name }}
+      {{- end}}
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: {{ .treehub_disk }}
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -93,40 +103,6 @@ spec:
       - backend:
           serviceName: treehub
           servicePort: 80
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: treehub-pvc
-spec:
-  accessModes: [ "ReadWriteOnce" ]
-  resources:
-    requests:
-      storage: {{ .treehub_disk }}
-  {{- if .persistent_volumes_path}}
-  selector:
-    matchLabels:
-      volume: treehub-pv
-  {{- end}}
-  {{- if .storage_class_name}}
-  storageClassName: {{ .storage_class_name }}
-  {{- end}}
----
-{{- if .persistent_volumes_path}}
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: treehub-pv
-  labels:
-    volume: treehub-pv
-spec:
-  capacity:
-    storage: 10Gi
-  accessModes: [ "ReadWriteOnce" ]
-  persistentVolumeReclaimPolicy: Retain
-  hostPath:
-    path: {{ .persistent_volumes_path }}
-{{- end}}
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
I know this didn't get much traction the first time, but I wanted to try 
once more now that the big refactor is working well:

PersistentVolumeClaims don't make much sense for things like
statefulSets that can have multiple replicas. volumeClaimTemplates
were created to solve this problem. They also work much better in
non-minikube environments where creating a persistent volume
requires some manual steps  in order to format the volume.

Additionally a change like this would then make it pretty trivial
to use something like:

 https://github.com/doanac/k8s-percona-xtradb-cluster

To have a multi-master HA mysql server.

Signed-off-by: Andy Doan <andy@opensourcefoundries.com>