### PR TITLE
Ingress: Make creation of Ingress optional

### DIFF
--- a/config/resources.yaml
+++ b/config/resources.yaml
@@ -64,3 +64,5 @@ zookeeper_cpu: 20m
 zookeeper_disk: 10Gi
 zookeeper_host: zookeeper
 zookeeper_mem: 100Mi
+
+create_ingress: true

--- a/templates/services/app.tmpl.yaml
+++ b/templates/services/app.tmpl.yaml
@@ -86,6 +86,7 @@ spec:
             port: 9001
             path: "/health"
 ---
+{{- if .create_ingress }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -103,6 +104,7 @@ spec:
           serviceName: app
           servicePort: 80
 ---
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/templates/services/gateway.tmpl.yaml
+++ b/templates/services/gateway.tmpl.yaml
@@ -104,6 +104,7 @@ spec:
         secret:
           secretName: gateway-tls
 ---
+{{- if .create_ingress }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -120,6 +121,7 @@ spec:
           serviceName: gateway
           servicePort: 8000
 ---
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/templates/services/treehub.tmpl.yaml
+++ b/templates/services/treehub.tmpl.yaml
@@ -84,6 +84,7 @@ spec:
         requests:
           storage: {{ .treehub_disk }}
 ---
+{{- if .create_ingress }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -101,6 +102,7 @@ spec:
           serviceName: treehub
           servicePort: 80
 ---
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/templates/services/tuf-reposerver.tmpl.yaml
+++ b/templates/services/tuf-reposerver.tmpl.yaml
@@ -58,6 +58,7 @@ spec:
             port: 9001
             path: "/health"
 ---
+{{- if .create_ingress }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -73,6 +74,7 @@ spec:
           serviceName: tuf-reposerver
           servicePort: 80
 ---
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/templates/services/web-events.tmpl.yaml
+++ b/templates/services/web-events.tmpl.yaml
@@ -50,6 +50,7 @@ spec:
             cpu: {{ .web_events_cpu }}
             memory: {{ .web_events_mem }}
 ---
+{{- if .create_ingress }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -68,6 +69,7 @@ spec:
           serviceName: web-events
           servicePort: 80
 ---
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
Given that the community edition has no default authentication, its
nice to have the ability to have a way to deploy it in a public cloud
without it being exposed.

Signed-off-by: Andy Doan <andy@opensourcefoundries.com>