### PR TITLE
scripts: Add a simple way to generate k8s templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ start-infra: %: start_%      ## Create infrastructure configs and apply to the c
 start-vaults: %: start_%     ## Start all vault instances.
 start-services: %: start_%   ## Start the OTA+ services.
 print-hosts: %: start_%      ## Print the service mappings for /etc/hosts
+templates: %: start_%        ## Generate all the k8s files
 
 start_%: # Pass the target as an argument to start.sh
 	@scripts/start.sh $*

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -17,7 +17,6 @@ readonly VAULT_SHARES=${VAULT_SHARES:-5}
 readonly VAULT_THRESHOLD=${VAULT_THRESHOLD:-3}
 
 readonly SKIP_CLIENT=${SKIP_CLIENT:-false}
-readonly SKIP_INGRESS=${SKIP_INGRESS:-false}
 readonly SKIP_WEAVE=${SKIP_WEAVE:-false}
 
 
@@ -64,6 +63,17 @@ kill_pid() {
   kill -9 "${pid}"
 }
 
+skip_ingress() {
+  [ -f config/local.yaml ] && local_yaml="config/local.yaml"
+
+  value=$(cat config/config.yaml \
+      config/images.yaml \
+      config/resources.yaml \
+      config/secrets.yaml \
+      $local_yaml | grep ^create_ingress | tail -n1)
+  echo $value | grep "false"
+}
+
 make_template() {
   local template=$1
   local output="${CWD}/../generated/${template}"
@@ -87,7 +97,7 @@ apply_template() {
 }
 
 generate_templates() {
-  [[ ${SKIP_INGRESS} == true ]] || make_template templates/ingress
+  skip_ingress || make_template templates/ingress
   make_template templates/infra
   make_template templates/services
   for vault in ${VAULTS:-tuf-vault crypt-vault}; do
@@ -243,7 +253,7 @@ start_weave() {
 }
 
 start_ingress() {
-  [[ ${SKIP_INGRESS} == true ]] && return 0;
+  skip_ingress && return 0;
   apply_template templates/ingress
 }
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -86,6 +86,16 @@ apply_template() {
   ${KUBECTL} apply --filename "${CWD}/../generated/${template}"
 }
 
+generate_templates() {
+  [[ ${SKIP_INGRESS} == true ]] || make_template templates/ingress
+  make_template templates/infra
+  make_template templates/services
+  for vault in ${VAULTS:-tuf-vault crypt-vault}; do
+    make_template "templates/vaults/${vault}.tmpl.yaml"
+    make_template "templates/jobs/${vault}-bootstrap.tmpl.yaml"
+  done
+}
+
 new_client() {
   export DEVICE_UUID=${DEVICE_UUID:-$(uuidgen | tr "[:upper:]" "[:lower:]")}
   local device_id=${DEVICE_ID:-${DEVICE_UUID}}
@@ -332,6 +342,9 @@ case "${command}" in
     ;;
   "print_hosts")
     print_hosts
+    ;;
+  "templates")
+    generate_templates
     ;;
   *)
     echo "Unknown command: ${command}"


### PR DESCRIPTION
I find this feature handy when doing things like code review, or trying
to understand what changes will happen before I do my next deployment.
With this command I can do things like:

 mv generated/templates generated/templates-cur
 make templates
 $YOUR_DIFF_TOOL generated/templates*

Signed-off-by: Andy Doan <andy@opensourcefoundries.com>