### PR TITLE
Add support for deploying to Google Kubernetes Engine

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,3 +4,4 @@ ingress_acl_whitelist: 0.0.0.0/0
 ingress_dns_name: ota.local
 ingress_proxy_size: 300m
 storage_class_name: standard
+gke_node_pool: false

--- a/contrib/gke/Dockerfile
+++ b/contrib/gke/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine
+
+COPY install-deps.sh /tmp/
+
+RUN apk --no-cache add openssh-client curl jq httpie python && \
+	/tmp/install-deps.sh && rm /tmp/install-deps.sh

--- a/contrib/gke/Dockerfile
+++ b/contrib/gke/Dockerfile
@@ -2,5 +2,5 @@ FROM alpine
 
 COPY install-deps.sh /tmp/
 
-RUN apk --no-cache add openssh-client curl jq httpie python && \
+RUN apk --no-cache add bash curl make openssh-client openssl jq httpie python && \
 	/tmp/install-deps.sh && rm /tmp/install-deps.sh

--- a/contrib/gke/README.md
+++ b/contrib/gke/README.md
@@ -24,6 +24,15 @@ Create the k8s cluster with:
  ./contrib/gke/gcloud container clusters get-credentials ota-ce
 ~~~
 
+## Deploy In Kubernetes
+
+~~~
+  ./contrib/gke/make SERVER_NAME="TODO" DNS_NAME="TODO" new-server
+  ./contrib/gke/make start-infra
+  ./contrib/gke/make VAULTS="tuf-vault" start-vaults
+  ./contrib/gke/make start-services
+~~~
+
 ## Cleaning Up
 The setup can be completed removed with:
 ~~~

--- a/contrib/gke/README.md
+++ b/contrib/gke/README.md
@@ -1,0 +1,32 @@
+# OTA Community Edition In Google Kubernetes Engine
+
+## Build container
+
+~~~
+  ./contrib/gke/docker-build.sh
+~~~
+
+## Initialze gcloud Environment
+
+A few commands need to be run to set up gcloud credentials:
+~~~
+ EXTRA_ARGS="-it" ./contrib/gke/gcloud auth login
+
+ ./contrib/gke/gcloud config set project <YOUR PROJECT>
+ ./contrib/gke/gcloud config set compute/zone us-central1-c
+~~~
+
+## Create Cluster
+
+Create the k8s cluster with:
+~~~
+ ./contrib/gke/gcloud container clusters create ota-ce --machine-type n1-standard-2
+ ./contrib/gke/gcloud container clusters get-credentials ota-ce
+~~~
+
+## Cleaning Up
+The setup can be completed removed with:
+~~~
+  # delete the cluster
+  ./contrib/gke/gcloud container clusters delete ota-ce --quiet
+~~~

--- a/contrib/gke/docker-build.sh
+++ b/contrib/gke/docker-build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+# ensure we execute from this directory
+cd $(dirname $(readlink -f $0))
+
+docker build -t otace-client .

--- a/contrib/gke/gcloud
+++ b/contrib/gke/gcloud
@@ -1,0 +1,14 @@
+#!/bin/sh -e
+
+GCLOUD_CONFIG="${GCLOUD_CONFIG-`pwd`/gcloud-config}"
+if [ ! -e $GCLOUD_CONFIG ] ; then
+	echo "Creating gcloud config on host at: $GCLOUD_CONFIG"
+	sudo mkdir $GCLOUD_CONFIG
+	sudo mkdir $GCLOUD_CONFIG/kube-config
+fi
+
+
+if [ "$1" = "shell" ] ; then
+	exec docker run --rm ${EXTRA_ARGS} -v ${GCLOUD_CONFIG}:/root/.config/gcloud otace-client /bin/sh
+fi
+exec docker run --rm ${EXTRA_ARGS} -v ${GCLOUD_CONFIG}:/root/.config/gcloud otace-client gcloud $*

--- a/contrib/gke/install-deps.sh
+++ b/contrib/gke/install-deps.sh
@@ -1,0 +1,18 @@
+#!/bin/sh -e
+
+echo "Install gcloud and kubectl"
+mkdir -p /opt && cd /opt
+curl https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.zip >sdk.zip
+unzip sdk.zip && rm sdk.zip
+google-cloud-sdk/install.sh --additional-components alpha beta gsutil kubectl
+
+ln -s /opt/google-cloud-sdk/bin/gcloud /usr/local/bin/
+ln -s /opt/google-cloud-sdk/bin/kubectl /usr/local/bin/
+ln -s /root/.config/gcloud/kube-config /root/.kube
+
+
+echo "Installing kops"
+cd /tmp
+curl -LO https://github.com/kubernetes/kops/releases/download/$(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | grep tag_name | cut -d '"' -f 4)/kops-linux-amd64
+chmod +x kops-linux-amd64
+mv kops-linux-amd64 /usr/local/bin/kops

--- a/contrib/gke/kubectl
+++ b/contrib/gke/kubectl
@@ -1,4 +1,4 @@
 #!/bin/sh -e
 
 GCLOUD_CONFIG="${GCLOUD_CONFIG-`pwd`/gcloud-config}"
-docker run --rm -v ${GCLOUD_CONFIG}:/root/.config/gcloud otace-client kubectl $*
+docker run --rm ${EXTRA_ARGS} -v ${GCLOUD_CONFIG}:/root/.config/gcloud otace-client kubectl $*

--- a/contrib/gke/kubectl
+++ b/contrib/gke/kubectl
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+
+GCLOUD_CONFIG="${GCLOUD_CONFIG-`pwd`/gcloud-config}"
+docker run --rm -v ${GCLOUD_CONFIG}:/root/.config/gcloud otace-client kubectl $*

--- a/templates/infra/kafka.tmpl.yaml
+++ b/templates/infra/kafka.tmpl.yaml
@@ -32,6 +32,10 @@ spec:
       labels:
         app: kafka
     spec:
+{{ if .gke_nodepool }}
+      nodeSelector:
+        cloud.google.com/gke-nodepool: {{ .gke_nodepool }}
+{{ end }}
       initContainers:
       - name: kafka-init
         image: {{ .init_docker_image }}

--- a/templates/infra/mysql.tmpl.yaml
+++ b/templates/infra/mysql.tmpl.yaml
@@ -20,6 +20,10 @@ spec:
       labels:
         app: mysql
     spec:
+{{ if .gke_nodepool }}
+      nodeSelector:
+        cloud.google.com/gke-nodepool: {{ .gke_nodepool }}
+{{ end }}
       containers:
       - image: {{ .mysql_docker_image }}
         name: mysql

--- a/templates/infra/zookeeper.tmpl.yaml
+++ b/templates/infra/zookeeper.tmpl.yaml
@@ -32,6 +32,10 @@ spec:
       labels:
         app: zookeeper
     spec:
+{{ if .gke_nodepool }}
+      nodeSelector:
+        cloud.google.com/gke-nodepool: {{ .gke_nodepool }}
+{{ end }}
       containers:
       - name: zookeeper
         image: {{ .zookeeper_docker_image }}

--- a/templates/services/app.tmpl.yaml
+++ b/templates/services/app.tmpl.yaml
@@ -59,6 +59,10 @@ spec:
       labels:
         app: app
     spec:
+{{ if .gke_nodepool }}
+      nodeSelector:
+        cloud.google.com/gke-nodepool: {{ .gke_nodepool }}
+{{ end }}
       containers:
       - image: {{ .app_docker_image }}
         name: app

--- a/templates/services/campaigner-daemon.tmpl.yaml
+++ b/templates/services/campaigner-daemon.tmpl.yaml
@@ -34,6 +34,10 @@ spec:
       labels:
         app: campaigner-daemon
     spec:
+{{ if .gke_nodepool }}
+      nodeSelector:
+        cloud.google.com/gke-nodepool: {{ .gke_nodepool }}
+{{ end }}
       containers:
       - name: campaigner-daemon
         image: {{ .campaigner_daemon_docker_image }}

--- a/templates/services/campaigner.tmpl.yaml
+++ b/templates/services/campaigner.tmpl.yaml
@@ -34,6 +34,10 @@ spec:
       labels:
         app: campaigner
     spec:
+{{ if .gke_nodepool }}
+      nodeSelector:
+        cloud.google.com/gke-nodepool: {{ .gke_nodepool }}
+{{ end }}
       containers:
       - name: campaigner
         image: {{ .campaigner_docker_image }}

--- a/templates/services/device-registry.tmpl.yaml
+++ b/templates/services/device-registry.tmpl.yaml
@@ -29,6 +29,10 @@ spec:
       labels:
         app: device-registry
     spec:
+{{ if .gke_nodepool }}
+      nodeSelector:
+        cloud.google.com/gke-nodepool: {{ .gke_nodepool }}
+{{ end }}
       containers:
       - name: device-registry
         image: {{ .device_registry_docker_image }}

--- a/templates/services/director-daemon.tmpl.yaml
+++ b/templates/services/director-daemon.tmpl.yaml
@@ -33,6 +33,10 @@ spec:
       labels:
         app: director-daemon
     spec:
+{{ if .gke_nodepool }}
+      nodeSelector:
+        cloud.google.com/gke-nodepool: {{ .gke_nodepool }}
+{{ end }}
       containers:
       - name: director-daemon
         image: {{ .director_daemon_docker_image }}

--- a/templates/services/director.tmpl.yaml
+++ b/templates/services/director.tmpl.yaml
@@ -33,6 +33,10 @@ spec:
       labels:
         app: director
     spec:
+{{ if .gke_nodepool }}
+      nodeSelector:
+        cloud.google.com/gke-nodepool: {{ .gke_nodepool }}
+{{ end }}
       containers:
       - name: director
         image: {{ .director_docker_image }}

--- a/templates/services/gateway.tmpl.yaml
+++ b/templates/services/gateway.tmpl.yaml
@@ -80,6 +80,10 @@ spec:
       labels:
         app: gateway
     spec:
+{{ if .gke_nodepool }}
+      nodeSelector:
+        cloud.google.com/gke-nodepool: {{ .gke_nodepool }}
+{{ end }}
       containers:
       - name: nginx
         image: {{ .nginx_docker_image }}

--- a/templates/services/treehub.tmpl.yaml
+++ b/templates/services/treehub.tmpl.yaml
@@ -35,6 +35,10 @@ spec:
       labels:
         app: treehub
     spec:
+{{ if .gke_nodepool }}
+      nodeSelector:
+        cloud.google.com/gke-nodepool: {{ .gke_nodepool }}
+{{ end }}
       {{- if eq .treehub_storage "local"}}
       initContainers:
       - name: treehub-init

--- a/templates/services/tuf-keyserver-daemon.tmpl.yaml
+++ b/templates/services/tuf-keyserver-daemon.tmpl.yaml
@@ -28,6 +28,10 @@ spec:
       labels:
         app: tuf-keyserver-daemon
     spec:
+{{ if .gke_nodepool }}
+      nodeSelector:
+        cloud.google.com/gke-nodepool: {{ .gke_nodepool }}
+{{ end }}
       containers:
       - name: tuf-keyserver-daemon
         image: {{ .tuf_keyserver_daemon_docker_image }}

--- a/templates/services/tuf-keyserver.tmpl.yaml
+++ b/templates/services/tuf-keyserver.tmpl.yaml
@@ -28,6 +28,10 @@ spec:
       labels:
         app: tuf-keyserver
     spec:
+{{ if .gke_nodepool }}
+      nodeSelector:
+        cloud.google.com/gke-nodepool: {{ .gke_nodepool }}
+{{ end }}
       containers:
       - name: tuf-keyserver
         image: {{ .tuf_keyserver_docker_image }}

--- a/templates/services/tuf-reposerver.tmpl.yaml
+++ b/templates/services/tuf-reposerver.tmpl.yaml
@@ -35,6 +35,10 @@ spec:
       labels:
         app: tuf-reposerver
     spec:
+{{ if .gke_nodepool }}
+      nodeSelector:
+        cloud.google.com/gke-nodepool: {{ .gke_nodepool }}
+{{ end }}
       containers:
       - name: tuf-reposerver
         image: {{ .tuf_reposerver_docker_image }}

--- a/templates/services/web-events.tmpl.yaml
+++ b/templates/services/web-events.tmpl.yaml
@@ -27,6 +27,10 @@ spec:
       labels:
         app: web-events
     spec:
+{{ if .gke_nodepool }}
+      nodeSelector:
+        cloud.google.com/gke-nodepool: {{ .gke_nodepool }}
+{{ end }}
       containers:
       - image: {{ .web_events_docker_image }}
         name: web-events


### PR DESCRIPTION
I realize deploying to GKE isn't really the original scope of a "community edition". However, I've found its hard to deploy to minikube w/o a really good machine and even then things are a little shaky. This gives users another way that might be easier for them to see things "just work" consistently. I've kept this as isolated as possible in a new "contrib" section.

Signed-off-by: Andy Doan <andy@opensourcefoundries.com>