### PR TITLE
[RFC] keyserver: Add logic for 0.4 built-in encryption

### DIFF
--- a/templates/services/tuf-keyserver-daemon.tmpl.yaml
+++ b/templates/services/tuf-keyserver-daemon.tmpl.yaml
@@ -10,8 +10,10 @@ data:
   DB_USER: {{ .tuf_keyserver_daemon_db_user }}
   JAVA_OPTS: {{ .tuf_keyserver_java_opts }}
   REPORT_METRICS: "false"
+{{ if contains .tuf_keyserver_daemon_docker_image ":0.3.0" }}
   TUF_VAULT_HOST: tuf-vault
   TUF_VAULT_PORT: '80'
+{{ end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -45,8 +47,13 @@ spec:
             name: tuf-keyserver-daemon-config
         - secretRef:
             name: tuf-keyserver-daemon-secret
+{{ if contains .tuf_keyserver_daemon_docker_image ":0.3.0" }}
         - secretRef:
             name: tuf-tokens
+{{ else }}
+        - secretRef:
+            name: tuf-keyserver-encryption
+{{ end }}
         ports:
         - containerPort: 9001
         resources:

--- a/templates/services/tuf-keyserver.tmpl.yaml
+++ b/templates/services/tuf-keyserver.tmpl.yaml
@@ -10,8 +10,10 @@ data:
   DB_USER: {{ .tuf_keyserver_db_user }}
   JAVA_OPTS: {{ .tuf_keyserver_java_opts }}
   REPORT_METRICS: "false"
+{{ if contains .tuf_keyserver_docker_image ":0.3." }}
   TUF_VAULT_HOST: tuf-vault
   TUF_VAULT_PORT: '80'
+{{ end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -45,8 +47,13 @@ spec:
             name: tuf-keyserver-config
         - secretRef:
             name: tuf-keyserver-secret
+{{ if contains .tuf_keyserver_docker_image ":0.3." }}
         - secretRef:
             name: tuf-tokens
+{{ else }}
+        - secretRef:
+            name: tuf-keyserver-encryption
+{{ end }}
         ports:
         - containerPort: 9001
         resources:


### PR DESCRIPTION
I would classify this as an RFC. After trying to spin up a new deployment I hit some of the usual difficulties with using the vault. This is my approach to *optionally* enable ota-tuf's built-in encryption. It can be enabled by creating a config/local.yaml:
~~~
tuf_keyserver_daemon_docker_image: advancedtelematic/tuf-keyserver:0.4.0-46-g0298f0a
tuf_keyserver_docker_image: advancedtelematic/tuf-keyserver:0.4.0-46-g0298f0a
tuf_reposerver_docker_image: advancedtelematic/tuf-reposerver:0.4.0-46-g0298f0a
~~~