### PR TITLE
treehub: Fix volume mounting issue

### DIFF
--- a/templates/services/treehub.tmpl.yaml
+++ b/templates/services/treehub.tmpl.yaml
@@ -74,7 +74,6 @@ spec:
         volumeMounts:
         - name: treehub-claim
           mountPath: /treehub-objects
-          subPath: treehub-objects
       {{- end}}
   volumeClaimTemplates:
   - metadata:


### PR DESCRIPTION
I could be missing something here, but on clean deployments I can't
get my treehub to start because of this "subPath" attribute.

Signed-off-by: Andy Doan <andy@opensourcefoundries.com>