### PR TITLE
Fix/implicit prov

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ However, OTA Community Edition supports only [**provisioning with device credent
 
 You must supply your yocto build with the credentials.zip, and specify that you want to provision with device credentials. Add the following lines to the `local.conf` of your Yocto build:
 
-    SOTA_CLIENT_PROV = "aktualizr-implicit-prov"
+    SOTA_CLIENT_PROV = "aktualizr-device-prov"
+    SOTA_DEPLOY_CREDENTIALS = "0"
     SOTA_PACKED_CREDENTIALS = "/path/to/ota.ce/generated/credentials.zip"
 
 Note that, if your build machine is different from the machine where minikube is running, you'll need to forward ports on the minikube machine and modify the build machine's hosts file as described above.

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -142,8 +142,11 @@ new_client() {
   local options="-o StrictHostKeyChecking=no"
 
   ssh ${options} "root@${addr}" -p "${port}" "echo \"${gateway} ota.ce\" >> /etc/hosts"
-  scp -P "${port}" ${options} "${device_dir}/client.pem" "root@${addr}:/var/sota/client.pem"
-  scp -P "${port}" ${options} "${device_dir}/pkey.pem" "root@${addr}:/var/sota/pkey.pem"
+  # TODO: is this the correct server/root CA cert?
+  scp -P "${port}" ${options} "${SERVER_DIR}/server_ca.pem" "root@${addr}:/var/sota/import/root.crt"
+  scp -P "${port}" ${options} "${device_dir}/client.pem" "root@${addr}:/var/sota/import/client.pem"
+  scp -P "${port}" ${options} "${device_dir}/pkey.pem" "root@${addr}:/var/sota/import/pkey.pem"
+  scp -P "${port}" ${options} "${SERVER_DIR}/autoprov.url" "root@${addr}:/var/sota/import/gateway.url"
 }
 
 new_server() {


### PR DESCRIPTION
I noticed that the ~~implicit~~ device credential provisioning explanation was a bit out of date, so that was relatively easy to fix. However, I think `new_client` is also stale. Ideally, it would just re-use `cert-provider` since that already exists to do a lot of that work and it was specifically designed for this type of use case. For example, see:

* [`cert_provider` in the aktualizr repo](https://github.com/advancedtelematic/aktualizr/blob/master/src/cert_provider/main.cc)
* [aktualizr ~~implicit~~ device credential provisioning test](https://github.com/advancedtelematic/aktualizr/blob/master/tests/device_cred_prov_test.py)
* [meta-updater ~~implicit~~ device credential provisioning](https://github.com/advancedtelematic/meta-updater/blob/master/recipes-sota/aktualizr/aktualizr-device-prov-creds.bb)
* [meta-updater ~~implicit~~ device credential provisioning test](https://github.com/advancedtelematic/meta-updater/blob/master/lib/oeqa/selftest/cases/updater_qemux86_64.py#L158)

If we aren't able to use `cert-provider`, then we need to supply `root.crt` and `gateway.url` ourselves, but I'm not quite sure where to get them. Step 4 of the [root certification doc in the quickstart guide](https://docs.ota.here.com/prod/generate-and-install-a-root-certificate.html) has an example, but I don't know where to get the credentials in `start.sh`.

~~@taheris can you perhaps guide me here? Or if it is obvious and easy for you to connect the pieces, please go ahead.~~ (Note that the second commit is likely not to work; it is just a WIP example idea.)