### PR TITLE
Upgrade deployments to appsv1

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ The following software tools are required to run the scripts in the
 current repository:
 
 * [minikube](https://github.com/kubernetes/minikube)
-* [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) (version >= 1.9)
-* [kops](https://github.com/kubernetes/kops) (version >= 1.9)
+* [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) (version >= 1.16)
+* [kops](https://github.com/kubernetes/kops) (version >= 1.16)
 * [jq](https://stedolan.github.io/jq/)
 * [httpie](https://httpie.org/)
 * [VirtualBox](https://www.virtualbox.org/)

--- a/templates/ingress/ingress.tmpl.yaml
+++ b/templates/ingress/ingress.tmpl.yaml
@@ -4,7 +4,7 @@ kind: Namespace
 metadata:
   name: ingress-nginx
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: default-http-backend
@@ -13,6 +13,9 @@ metadata:
   namespace: ingress-nginx
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: default-http-backend
   template:
     metadata:
       labels:
@@ -204,7 +207,7 @@ subjects:
     name: nginx-ingress-serviceaccount
     namespace: ingress-nginx
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-ingress-controller


### PR DESCRIPTION
Running `make start` gave me the following error:

```
unable to recognize "/home/dburnsii/Documents/ota-community-edition/scripts/../generated/templates/ingress": no matches for kind "Deployment" in version "extensions/v1beta1"
unable to recognize "/home/dburnsii/Documents/ota-community-edition/scripts/../generated/templates/ingress": no matches for kind "Deployment" in version "extensions/v1beta1"
```

Upgrading the Deployments from `extensions/v1beta1` to `apps/v1` seems to resolve the issue:

https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/