### PR TITLE
Add macOS support for instantiating the server

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -225,7 +225,7 @@ configure_db_encryption() {
   ${KUBECTL} get secret "tuf-keyserver-encryption" &>/dev/null && return 0
 
   local salt=$(openssl rand -base64 8)
-  local key=$(tr -cd '[:alnum:]' < /dev/urandom | fold -w64 | head -n1)
+  local key=$(LC_CTYPE=C tr -cd '[:alnum:]' < /dev/urandom | fold -w64 | head -n1)
 
   ${KUBECTL} create secret generic "tuf-keyserver-encryption" \
     --from-literal="DB_ENCRYPTION_SALT=${salt}" \


### PR DESCRIPTION
These two commits are needed to resolves issues I identified when bringing up OTA Community Edition on macOS Catalina 10.15.6.

macOS uses LibreSSL instead of OpenSSL. LibreSSL does not support the ENV feature for setting variables in cnf files.

tr /dev/urandom returns illegal byte sequence (https://unix.stackexchange.com/questions/45404/why-cant-tr-read-from-dev-urandom-on-osx). The fix is to set the locale to C by prefixing the command with LC_TYPE=C. Apparently, this should be LC_ALL=C for OSX 10.9 and before but this is getting very old. There was also a solution that used perl instead of tr.