### PR TITLE
Use internal variables to generate proper tuf-reposerver url in start.sh:get_credentials function

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -259,7 +259,8 @@ get_credentials() {
 
   http_2xx_or_4xx --ignore-stdin --check-status POST "${reposerver}/api/v1/user_repo" "${namespace}"
 
-  id=$(http --ignore-stdin --check-status --print=h GET http://tuf-reposerver.ota.local/api/v1/user_repo/root.json x-ats-namespace:default | grep x-ats-tuf-repo-id | awk '{print $2}' | tr -d '\r')
+  id=$(http --ignore-stdin --check-status --print=h GET "${reposerver}/api/v1/user_repo/root.json" "${namespace}" | grep -i x-ats-tuf-repo-id | awk '{print $2}' | tr -d '\r')
+  echo "id=${id}"
 
   http_2xx_or_4xx --ignore-stdin --check-status POST "${director}/api/v1/admin/repo" "${namespace}"
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -261,7 +261,6 @@ get_credentials() {
 
   sleep 5s
   id=$(http --ignore-stdin --check-status --print=h GET "${reposerver}/api/v1/user_repo/root.json" "${namespace}" | grep -i x-ats-tuf-repo-id | awk '{print $2}' | tr -d '\r')
-  echo "id=${id}"
 
   http_2xx_or_4xx --ignore-stdin --check-status POST "${director}/api/v1/admin/repo" "${namespace}"
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -259,6 +259,7 @@ get_credentials() {
 
   http_2xx_or_4xx --ignore-stdin --check-status POST "${reposerver}/api/v1/user_repo" "${namespace}"
 
+  sleep 5s
   id=$(http --ignore-stdin --check-status --print=h GET "${reposerver}/api/v1/user_repo/root.json" "${namespace}" | grep -i x-ats-tuf-repo-id | awk '{print $2}' | tr -d '\r')
   echo "id=${id}"
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -225,7 +225,7 @@ configure_db_encryption() {
   ${KUBECTL} get secret "tuf-keyserver-encryption" &>/dev/null && return 0
 
   local salt=$(openssl rand -base64 8)
-  local key=$(tr -cd '[:alnum:]' < /dev/urandom | fold -w64 | head -n1)
+  local key=$(LC_CTYPE=C tr -cd '[:alnum:]' < /dev/urandom | fold -w64 | head -n1)
 
   ${KUBECTL} create secret generic "tuf-keyserver-encryption" \
     --from-literal="DB_ENCRYPTION_SALT=${salt}" \


### PR DESCRIPTION
The tuf-reposerver url fix is not dependent on the macOS changes. Not sure if I am creating this pull request correctly.

The two commits needed are:

- Fix tuf-reposerver url when generating server keys
- Resolve HTTP 423 Locked error

The second fix is a bit crude. If there is an actual entity we could wait on, that would be better. I did try a 2s sleep, but that was not sufficient.